### PR TITLE
Excluded the full aws-java-sdk library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,28 +132,15 @@
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-core</artifactId>
+            <version>${aws.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
             <version>${aws.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-ec2</artifactId>
-            <version>${aws.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-                    <artifactId>aws-java-sdk-elasticloadbalancing</artifactId>
-                    <version>${aws.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk</artifactId>
-            <version>${aws.version}</version>
-        </dependency>
-
 
     </dependencies>
     <build>


### PR DESCRIPTION
Excluded the full aws-java-sdk library and only include the necessary ones to avoid having applications using this library become unnecessary large.