### PR TITLE
Endponit Not Empty

### DIFF
--- a/src/org/jgroups/aws/s3/NATIVE_S3_PING.java
+++ b/src/org/jgroups/aws/s3/NATIVE_S3_PING.java
@@ -85,7 +85,7 @@ public class NATIVE_S3_PING extends FILE_PING {
 
         DefaultAWSCredentialsProviderChain creds=DefaultAWSCredentialsProviderChain.getInstance();
         AmazonS3ClientBuilder builder=AmazonS3ClientBuilder.standard().withCredentials(creds).withPathStyleAccessEnabled(path_style_access_enabled);
-        if(endpoint != null) {
+        if(!StringUtils.isNullOrEmpty(endpoint)) {
             builder=builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region_name));
             log.info("set Amazon S3 endpoint to %s", endpoint);
         } else {

--- a/src/org/jgroups/aws/s3/NATIVE_S3_PING.java
+++ b/src/org/jgroups/aws/s3/NATIVE_S3_PING.java
@@ -106,12 +106,14 @@ public class NATIVE_S3_PING extends FILE_PING {
             log.info("found bucket %s\n", bucket_name);
 
         // Initialize the bucket owner full control grant.
-        BUCKET_OWNER_FULL_CONTROL_ACL.grantAllPermissions(new Grant[] {
-            new Grant(
-                new CanonicalGrantee(s3.getS3AccountOwner().getId()),
-                Permission.FullControl
-            )
-        });
+        if (acl_grant_bucket_owner_full_control) {
+            BUCKET_OWNER_FULL_CONTROL_ACL.grantAllPermissions(new Grant[]{
+                    new Grant(
+                            new CanonicalGrantee(s3.getS3AccountOwner().getId()),
+                            Permission.FullControl
+                    )
+            });
+        }
     }
 
     @Override


### PR DESCRIPTION
Check if endponit is not empty in addition to null
Useful when you need to use expressions in the config file like `${env.S3_PING_BUCKET_ENDPOINT:}`

Chekc also `acl_grant_bucket_owner_full_control` in init because if not have permission received `Service: Amazon S3; Status Code: 403; Error Code: AccessDenied`