### PR TITLE
chore: Remove outdated TODO comment about forcePathStyle

### DIFF
--- a/src/main/java/org/jgroups/protocols/aws/S3_PING.java
+++ b/src/main/java/org/jgroups/protocols/aws/S3_PING.java
@@ -116,7 +116,6 @@ public class S3_PING extends FILE_PING {
         S3ClientBuilder builder = S3Client.builder();
         builder.credentialsProvider(DefaultCredentialsProvider.builder().build());
 
-        // TODO Is this meant to replace #withPathStyleAccessEnabled ?
         builder.forcePathStyle(path_style_access_enabled);
 
         Region region = Region.of(region_name);


### PR DESCRIPTION
The forcePathStyle() method is the correct AWS SDK v2 replacement for the deprecated withPathStyleAccessEnabled() method.