### PR TITLE
fix: Close S3Client in destroy(); the S3Client created in init() was …

### DIFF
--- a/src/main/java/org/jgroups/protocols/aws/S3_PING.java
+++ b/src/main/java/org/jgroups/protocols/aws/S3_PING.java
@@ -156,6 +156,14 @@ public class S3_PING extends FILE_PING {
     }
 
     @Override
+    public void destroy() {
+        super.destroy();
+
+        // SdkAutoCloseable does not throw checked exceptions in its close() methods
+        s3Client.close();
+    }
+
+    @Override
     protected void createRootDir() {
         // ignore, bucket has to exist
     }


### PR DESCRIPTION
…never closed, leaking HTTP connections.