### PR TITLE
fix: guard against NPE in destroy() when s3Client was never initialized

### DIFF
--- a/src/main/java/org/jgroups/protocols/aws/S3_PING.java
+++ b/src/main/java/org/jgroups/protocols/aws/S3_PING.java
@@ -168,7 +168,7 @@ public class S3_PING extends FILE_PING {
         // Workaround for https://issues.redhat.com/browse/JGRP-2976
         // In case a shutdown hook was registered, JGroups never deregisters it on stop, so the client must be still
         // available during JVM shutdown.
-        if (!register_shutdown_hook) {
+        if (!register_shutdown_hook && s3Client != null) {
             // SdkAutoCloseable does not throw checked exceptions in its close() methods
             s3Client.close();
         }


### PR DESCRIPTION
## Summary

Fixes #557.

If `S3_PING.init()` fails due to misconfiguration before the `S3Client` is built and assigned, JGroups calls `destroy()` on the protocol stack for cleanup. The null `s3Client` field then causes a `NullPointerException` in `destroy()` that masks the original configuration error with a confusing secondary exception.

The fix adds a null guard to the `s3Client.close()` call in `destroy()` so that cleanup is safely skipped when the client was never initialized.